### PR TITLE
Reminder: Fix remind message being optional

### DIFF
--- a/reminder/module.py
+++ b/reminder/module.py
@@ -232,7 +232,7 @@ class Reminder(commands.Cog):
     @commands.check(check.acl)
     @commands.command()
     async def remind(
-        self, ctx, member: nextcord.Member, datetime_str: str, *, text: str
+        self, ctx, member: nextcord.Member, datetime_str: str, *, text: Optional[str]
     ):
         """Create reminder for another user.
         Args:


### PR DESCRIPTION
Argument `text` in `remind` command was described as Optional, but it was not.