### PR TITLE
Reminder: Ensure rescheduled events are always reminded

### DIFF
--- a/reminder/module.py
+++ b/reminder/module.py
@@ -458,6 +458,7 @@ class Reminder(commands.Cog):
             await ctx.send(_(ctx, "Reschedule timed out."))
         elif value:
             query.remind_date = date
+            query.status = ReminderStatus.WAITING
             query.save()
             await ctx.send(_(ctx, "Reminder rescheduled."))
             await guild_log.debug(


### PR DESCRIPTION
When you reschedule an event that was already triggered, it would not remind you again, because the status would not be reset.

Resolves #22