### PR TITLE
 Fix NoneType Length Check in Reminder Handling

### DIFF
--- a/reminder/module.py
+++ b/reminder/module.py
@@ -144,7 +144,8 @@ class Reminder(commands.Cog):
             reminder.remind_date = item.remind_date.strftime("%Y-%m-%d %H:%M")
             reminder.status = item.status.name
             reminder.message = item.message
-            if len(reminder.message) > 30:
+
+            if reminder.message and len(reminder.message) > 30:
                 reminder.message = reminder.message[:29] + "\N{HORIZONTAL ELLIPSIS}"
 
             reminders.append(reminder)


### PR DESCRIPTION
Added a condition to verify that `reminder.message` is not `None` before checking its length and slicing the string.

![error_picture](https://github.com/pumpkin-py/pumpkin-reminder/assets/107799077/a143b326-f296-40e0-9a4f-bda852f21059)
